### PR TITLE
Expanded Image Modal + Cleaned up console.log littering

### DIFF
--- a/client/dist/stylesheet.css
+++ b/client/dist/stylesheet.css
@@ -19,8 +19,8 @@
 #expanded-image {
   width: 800px;
   height: 500px;
-  /* margin-left: 20%; */
   margin-top: 5%;
+  object-fit: cover;
 }
 
 .expanded-view-container {

--- a/client/dist/stylesheet.css
+++ b/client/dist/stylesheet.css
@@ -1,3 +1,63 @@
+.left-arrow-expanded {
+  position: absolute;
+  color: pink;
+  bottom: 50%;
+  left: 15px;
+}
+
+#expanded-image-container {
+  position: relative;
+}
+
+.right-arrow-expanded {
+  position: absolute;
+  color: pink;
+  bottom: 50%;
+  right: 15px;
+}
+
+#expanded-image {
+  width: 800px;
+  height: 500px;
+  /* margin-left: 20%; */
+  margin-top: 5%;
+}
+
+.expanded-view-container {
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width:100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+}
+
+.modal-main {
+  position:fixed;
+  background: transparent;
+  width: 80%;
+  height: auto;
+  top:50%;
+  left:50%;
+  transform: translate(-50%,-50%);
+
+}
+
+.display-block {
+  display: block;
+}
+
+.display-none {
+  display: none;
+}
+
 .slider-thumbnail {
   width: 65px;
   height: 65px;

--- a/client/dist/stylesheet.css
+++ b/client/dist/stylesheet.css
@@ -1,11 +1,71 @@
+.expanded-image {
+  width: 800px;
+  height: 500px;
+  margin-top: 5%;
+  object-fit: cover;
+  cursor: zoom-in;
+}
+
+.expanded-image.zoom-view {
+  /* background-size: 250%; */
+  width: 2000px;
+  height: 1250px;
+  cursor: zoom-out;
+
+}
+
+.fa-times {
+  position: absolute;
+  top: 55px;
+  right: 20px;
+  color: pink;
+  cursor: pointer;
+  text-shadow: -1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000;
+
+
+}
+
+.fa-times:hover {
+ color:white
+
+}
+
+.fa-circle {
+  color:pink;
+  margin-right: 10px;
+  cursor: pointer;
+  text-shadow: -1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000;
+
+
+}
+
+.fa-circle.clickedCircle {
+  color: white
+}
+
+.fa-circle:hover {
+  color:white;
+
+}
+
+#circles {
+  position: absolute;
+  left: 35%;
+  top: 15%
+}
+
 .left-arrow-expanded {
   position: absolute;
   color: pink;
   bottom: 50%;
   left: 15px;
+  text-shadow: -1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000;
+
 }
 
+
 #expanded-image-container {
+
   position: relative;
 }
 
@@ -14,14 +74,11 @@
   color: pink;
   bottom: 50%;
   right: 15px;
+  text-shadow: -1px 0 #000, 0 1px #000, 1px 0 #000, 0 -1px #000;
+
 }
 
-#expanded-image {
-  width: 800px;
-  height: 500px;
-  margin-top: 5%;
-  object-fit: cover;
-}
+
 
 .expanded-view-container {
   display: flex;
@@ -67,9 +124,10 @@
 
 }
 
-.sliderThumbnailSelected {
-  opacity: 1;
+.slider-thumbnail.active-thumbnail {
+  opacity: 1
 }
+
 
 
 .slider-thumbnail:hover {
@@ -128,6 +186,7 @@
   width: 500px;
   height: 400px;
   object-fit: cover;
+  cursor: pointer;
 }
 
 
@@ -188,6 +247,8 @@
   object-fit: cover;
 
 }
+
+
 
 .thumbnail-image:hover {
   background-color: pink;

--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -194,6 +194,15 @@ class Overview extends React.Component {
     this.setState({expandedView: true});
   }
 
+  handleCircleClick() {
+    console.log('a');
+
+  }
+
+  handleExpandedImageClose(e) {
+    this.setState({expandedView: null});
+  }
+
   render () {
 
     return (
@@ -210,6 +219,8 @@ class Overview extends React.Component {
           </div>
 
           <ExpandedView images = {this.state.images}
+            handleExpandedImageClose = {this.handleExpandedImageClose.bind(this)}
+            handleCircleClick = {this.handleCircleClick.bind(this)}
             selectedStyle = {this.state.selectedStyle}
             expandedView = {this.state.expandedView}/>
 

--- a/client/src/components/Overview.jsx
+++ b/client/src/components/Overview.jsx
@@ -8,6 +8,7 @@ import AddToCart from './OverviewComponents/AddToCart.jsx';
 import ProductDescription from './OverviewComponents/ProductDescription.jsx';
 import ImageGallery from './OverviewComponents/ImageGallery.jsx';
 import MainImage from './OverviewComponents/MainImage.jsx';
+import ExpandedView from './OverviewComponents/ExpandedView.jsx';
 
 class Overview extends React.Component {
   constructor(props) {
@@ -30,7 +31,8 @@ class Overview extends React.Component {
       validATC: null,
       productDescription: null,
       productSlogan: null,
-      salePrice: null
+      salePrice: null,
+      expandedView: null
 
     };
   }
@@ -188,8 +190,9 @@ class Overview extends React.Component {
     }
   }
 
-
-
+  showExpandedView() {
+    this.setState({expandedView: true});
+  }
 
   render () {
 
@@ -199,10 +202,16 @@ class Overview extends React.Component {
         <div className = 'overview-container'>
 
           <div className = 'image-gallery-container'>
-            <ImageGallery
+            <ImageGallery expandedView = {this.state.expandedView}
+              showExpandedView = {this.showExpandedView.bind(this)}
               length = {this.state.images ? this.state.images[Number(this.state.selectedStyle)].length : ''}
-              selectedStyle = {this.state.selectedStyle} images = {this.state.images} />
+              selectedStyle = {this.state.selectedStyle}
+              images = {this.state.images} />
           </div>
+
+          <ExpandedView images = {this.state.images}
+            selectedStyle = {this.state.selectedStyle}
+            expandedView = {this.state.expandedView}/>
 
           <div className = 'info-container'>
             <StarRating rating ={this.state.rating}/>

--- a/client/src/components/OverviewComponents/AddToCart.jsx
+++ b/client/src/components/OverviewComponents/AddToCart.jsx
@@ -12,14 +12,14 @@ class AddToCart extends React.Component {
     // Else if <15, user selects from 1 to the quantity in stock
     var output = [];
     if (!this.props.quantity) {
-      output.push(<option>—</option>);
+      output.push(<option key = {'-'}>—</option>);
     } else if (this.props.quantity >= 15) {
       for (var i = 1; i <= 15; i++) {
-        output.push(<option>{i}</option>);
+        output.push(<option key = {i}>{i}</option>);
       }
     } else {
       for (var i = 1; i <= this.props.quantity; i++) {
-        output.push(<option>{i}</option>);
+        output.push(<option key = {i}>{i}</option>);
       }
     }
 
@@ -39,8 +39,8 @@ class AddToCart extends React.Component {
           <div className="select-dropdown">
             <select onChange = {this.props.handleSizeSelect}>
 
-              {this.props.outOfStock ? <option >OUT OF STOCK</option> : <option >Select Size</option>}
-              {!this.props.outOfStock ? this.props.sizes.map(size => <option >{size}</option>) : '' }
+              {this.props.outOfStock ? <option key = {'outofStock'} >OUT OF STOCK</option> : <option key = {'selectSize'} >Select Size</option>}
+              {!this.props.outOfStock ? this.props.sizes.map( (size, i) => <option key = {i}>{size}</option>) : '' }
 
             </select>
           </div>

--- a/client/src/components/OverviewComponents/Circles.jsx
+++ b/client/src/components/OverviewComponents/Circles.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+
+class Circles extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+
+
+  render () {
+
+    return (
+      <div id = 'circles'>
+        {this.props.images.map( (image, i) => {
+          return <i className = {this.props.currentIndex === i ? 'fas fa-circle clickedCircle' : 'fas fa-circle'} onClick = {this.props.handleCircleClick} key = {i} id = {Number(i)}></i>;
+        })}
+
+      </div>
+    );
+
+  }
+
+}
+export default Circles;

--- a/client/src/components/OverviewComponents/ExpandedView.jsx
+++ b/client/src/components/OverviewComponents/ExpandedView.jsx
@@ -2,13 +2,14 @@ import React from 'react';
 import ReactDom from 'react-dom';
 import LeftArrowExpanded from './LeftArrowExpanded.jsx';
 import RightArrowExpanded from './RightArrowExpanded.jsx';
-
+import Circles from './Circles.jsx';
 
 class ExpandedView extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentIndex: 0
+      currentIndex: 0,
+      zoomView: null
     };
   }
 
@@ -30,9 +31,22 @@ class ExpandedView extends React.Component {
     }
   }
 
+  handleCircleClick(e) {
+    this.setState({currentIndex: Number(e.target.getAttribute('id'))});
+  }
+
+  handleExpandedImageClick() {
+    if (this.state.zoomView) {
+      this.setState({zoomView: null});
+    } else {
+      this.setState({zoomView: true});
+    }
+  }
+
+
+
   render () {
     if (this.props.images) {
-      console.log(this.props.images[Number(this.props.selectedStyle)]);
 
     }
 
@@ -43,11 +57,13 @@ class ExpandedView extends React.Component {
           <div className = 'modal display-block'>
 
             <div className= ".modal-main">
-              <div class = 'expanded-view-container'>
+              <div className = 'expanded-view-container'>
                 <div id = 'expanded-image-container'>
+                  <Circles currentIndex = {this.state.currentIndex} handleCircleClick = {this.handleCircleClick.bind(this)} images = {this.props.images[Number(this.props.selectedStyle)]}/>
                   <LeftArrowExpanded handleLeftArrowExpanded = {this.handleLeftArrowExpanded.bind(this)} />
-                  <img id = 'expanded-image' src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][this.state.currentIndex].url : ''}
+                  <img className = {this.state.zoomView ? 'expanded-image zoom-view' : 'expanded-image'} onClick = {this.handleExpandedImageClick.bind(this)} src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][this.state.currentIndex].url : ''}
                   />
+                  <i onClick = {this.props.handleExpandedImageClose} className="fas fa-times fa-2x"></i>
                   <RightArrowExpanded handleRightArrowExpanded = {this.handleRightArrowExpanded.bind(this)}/>
                 </div>
               </div>

--- a/client/src/components/OverviewComponents/ExpandedView.jsx
+++ b/client/src/components/OverviewComponents/ExpandedView.jsx
@@ -7,6 +7,27 @@ import RightArrowExpanded from './RightArrowExpanded.jsx';
 class ExpandedView extends React.Component {
   constructor(props) {
     super(props);
+    this.state = {
+      currentIndex: 0
+    };
+  }
+
+  handleLeftArrowExpanded() {
+    var length = this.props.images[Number(this.props.selectedStyle)].length;
+    if (this.state.currentIndex === 0) {
+      this.setState({currentIndex: length - 1});
+    } else {
+      this.setState({currentIndex: this.state.currentIndex - 1});
+    }
+  }
+
+  handleRightArrowExpanded() {
+    var length = this.props.images[Number(this.props.selectedStyle)].length;
+    if (this.state.currentIndex === length - 1) {
+      this.setState({currentIndex: 0});
+    } else {
+      this.setState({currentIndex: this.state.currentIndex + 1});
+    }
   }
 
   render () {
@@ -14,6 +35,7 @@ class ExpandedView extends React.Component {
       console.log(this.props.images[Number(this.props.selectedStyle)]);
 
     }
+
 
     return ReactDom.createPortal(
       <>
@@ -23,10 +45,10 @@ class ExpandedView extends React.Component {
             <div className= ".modal-main">
               <div class = 'expanded-view-container'>
                 <div id = 'expanded-image-container'>
-                  <LeftArrowExpanded />
-                  <img id = 'expanded-image' src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][0].url : ''}
+                  <LeftArrowExpanded handleLeftArrowExpanded = {this.handleLeftArrowExpanded.bind(this)} />
+                  <img id = 'expanded-image' src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][this.state.currentIndex].url : ''}
                   />
-                  <RightArrowExpanded />
+                  <RightArrowExpanded handleRightArrowExpanded = {this.handleRightArrowExpanded.bind(this)}/>
                 </div>
               </div>
             </div>

--- a/client/src/components/OverviewComponents/ExpandedView.jsx
+++ b/client/src/components/OverviewComponents/ExpandedView.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+import LeftArrowExpanded from './LeftArrowExpanded.jsx';
+import RightArrowExpanded from './RightArrowExpanded.jsx';
+
+
+class ExpandedView extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render () {
+    if (this.props.images) {
+      console.log(this.props.images[Number(this.props.selectedStyle)]);
+
+    }
+
+    return ReactDom.createPortal(
+      <>
+        {this.props.expandedView ?
+          <div className = 'modal display-block'>
+
+            <div className= ".modal-main">
+              <div class = 'expanded-view-container'>
+                <div id = 'expanded-image-container'>
+                  <LeftArrowExpanded />
+                  <img id = 'expanded-image' src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][0].url : ''}
+                  />
+                  <RightArrowExpanded />
+                </div>
+              </div>
+            </div>
+
+          </div> :
+          <div className = '.modal display-none'>
+
+            <div className= ".modal-main">
+              <img id = 'expanded-image' src = {this.props.images ? this.props.images[Number(this.props.selectedStyle)][0].url : ''}/>
+            </div>
+
+          </div> }
+      </>,
+      document.getElementById('thumbnail-portal')
+
+    );
+
+  }
+
+}
+export default ExpandedView;

--- a/client/src/components/OverviewComponents/ImageGallery.jsx
+++ b/client/src/components/OverviewComponents/ImageGallery.jsx
@@ -110,7 +110,7 @@ class ImageGallery extends React.Component {
         <div className = 'main-image-container'>
 
           <LeftArrow className = {this.state.currentIndex === 0 ? 'pink' : ''} handleLeftArrow = {this.handleLeftArrow.bind(this)}/>
-          <MainImage currentIndex = {this.state.currentIndex} selectedStyle = {this.props.selectedStyle} images = {this.props.images}/>
+          <MainImage showExpandedView = {this.props.showExpandedView} currentIndex = {this.state.currentIndex} selectedStyle = {this.props.selectedStyle} images = {this.props.images}/>
           {this.state.currentIndex === this.props.length - 1 ? '' :
             <RightArrow handleRightArrow = {this.handleRightArrow.bind(this)}/>}
         </div>

--- a/client/src/components/OverviewComponents/ImageGallery.jsx
+++ b/client/src/components/OverviewComponents/ImageGallery.jsx
@@ -56,7 +56,7 @@ class ImageGallery extends React.Component {
 
 
   handleSliderThumbnailClick(event) {
-    this.setState({currentIndex: Number(event.target.getAttribute('thumbnailId'))});
+    this.setState({currentIndex: Number(event.target.getAttribute('thumbnailid'))});
   }
 
 

--- a/client/src/components/OverviewComponents/LeftArrowExpanded.jsx
+++ b/client/src/components/OverviewComponents/LeftArrowExpanded.jsx
@@ -10,8 +10,8 @@ class LeftArrowExpanded extends React.Component {
   render () {
     return (
       <>
-        <div className='left-arrow-expanded' onClick={this.props.handleLeftArrow}>
-          <i className='fa fa-angle-left fa-3x'></i>
+        <div className='left-arrow-expanded' >
+          <i onClick={this.props.handleLeftArrowExpanded} className='fa fa-angle-left fa-3x'></i>
         </div>
       </>
     );

--- a/client/src/components/OverviewComponents/LeftArrowExpanded.jsx
+++ b/client/src/components/OverviewComponents/LeftArrowExpanded.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+
+class LeftArrowExpanded extends React.Component {
+  constructor(props) {
+    super(props);
+
+  }
+
+  render () {
+    return (
+      <>
+        <div className='left-arrow-expanded' onClick={this.props.handleLeftArrow}>
+          <i className='fa fa-angle-left fa-3x'></i>
+        </div>
+      </>
+    );
+
+  }
+
+}
+export default LeftArrowExpanded;

--- a/client/src/components/OverviewComponents/MainImage.jsx
+++ b/client/src/components/OverviewComponents/MainImage.jsx
@@ -15,7 +15,7 @@ class MainImage extends React.Component {
 
     return (
       <>
-        {this.props.images ? <img id = 'main-image' src = {this.props.images[Number(this.props.selectedStyle)][this.props.currentIndex].url} /> : ''}
+        {this.props.images ? <img onClick = {this.props.showExpandedView} id = 'main-image' src = {this.props.images[Number(this.props.selectedStyle)][this.props.currentIndex].url} /> : ''}
       </>
     );
 

--- a/client/src/components/OverviewComponents/RightArrowExpanded.jsx
+++ b/client/src/components/OverviewComponents/RightArrowExpanded.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+
+class RightArrowExpanded extends React.Component {
+  constructor(props) {
+    super(props);
+
+  }
+
+  render () {
+    return (
+      <>
+        <div className='right-arrow-expanded' onClick={this.props.handleLeftArrowSlider}>
+          <i className='fa fa-angle-right fa-3x'></i>
+        </div>
+      </>
+    );
+
+  }
+
+}
+export default RightArrowExpanded;

--- a/client/src/components/OverviewComponents/RightArrowExpanded.jsx
+++ b/client/src/components/OverviewComponents/RightArrowExpanded.jsx
@@ -11,7 +11,7 @@ class RightArrowExpanded extends React.Component {
     return (
       <>
         <div className='right-arrow-expanded' onClick={this.props.handleLeftArrowSlider}>
-          <i className='fa fa-angle-right fa-3x'></i>
+          <i onClick={this.props.handleRightArrowExpanded} className='fa fa-angle-right fa-3x'></i>
         </div>
       </>
     );

--- a/client/src/components/OverviewComponents/Slider.jsx
+++ b/client/src/components/OverviewComponents/Slider.jsx
@@ -18,7 +18,8 @@ class Slider extends React.Component {
 
           {this.props.images ? this.props.images[Number(this.props.selectedStyle)].map( (photo, i) => {
             if (i <= this.props.imageRange[1] && i >= this.props.imageRange[0]) {
-              return <img className = {this.props.currentIndex === i ? 'sliderThumbnailSelected' : '' } onClick = {this.props.handleSliderThumbnailClick} thumbnailId = {i} className = 'slider-thumbnail' src = {photo.url}/>;
+
+              return <img key = {i} className = {this.props.currentIndex === i ? 'slider-thumbnail active-thumbnail' : 'slider-thumbnail' } onClick = {this.props.handleSliderThumbnailClick} thumbnailid = {i} className = 'slider-thumbnail' src = {photo.url}/>;
             }
           })
             : '' }

--- a/client/src/components/OverviewComponents/StyleSelector.jsx
+++ b/client/src/components/OverviewComponents/StyleSelector.jsx
@@ -21,13 +21,13 @@ class StyleSelector extends React.Component {
 
       // if style is selected, then add a checkmark to DOM. Else, don't add
       if (this.props.selectedStyle.toString() === i.toString()) {
-        element = [<div id = 'image-container'> <img id = {this.props.thumbnails[i].index}
+        element = [<div key = {i} id = 'image-container'> <img id = {this.props.thumbnails[i].index}
           className = 'thumbnail-image'
           onClick = {this.props.handleStyleClick} src = {this.props.thumbnails[i].url} />
-        <i class="fas fa-check fa-lg"></i> </div>];
+        <i className="fas fa-check fa-lg"></i> </div>];
       } else {
-        element = [<div id = 'image-container'>
-          <img id = {this.props.thumbnails[i].index}
+        element = [<div key = {i} id = 'image-container'>
+          <img key = {i} id = {this.props.thumbnails[i].index}
             className = 'thumbnail-image' onClick = {this.props.handleStyleClick}
             src = {this.props.thumbnails[i].url} /> </div>];
       }


### PR DESCRIPTION
Clicking on product image brings up expanded image modal. Still working on zoom-in functionality that should zoom image modal upon click.

Fixed issue with 'key' and 'className' React errors littering our console log.